### PR TITLE
ci: fix Codecov upload

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -68,6 +68,8 @@ jobs:
           path: coverage/lcov-report
       - name: 'Upload coverage to Codecov'
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   publish:
     name: Publish to NPM
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Ah the token is now needed with `codecov/codecov-action@v4`

https://github.com/codecov/codecov-action/issues/1293